### PR TITLE
Parallel processing for realtime dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,9 +51,9 @@ $ conda activate cchd
 $ conda install -c conda-forge panel hvplot geoviews colorcet pandas geopandas
 ```
 
-Note: the realtime dashboard uses files from the [Iris sample data repository](https://github.com/SciTools/iris-sample-data) directly, rather than pre-processing the same data. This adds an extra dependency:
+Note: the realtime dashboard uses both dask distributed and files from the [Iris sample data repository](https://github.com/SciTools/iris-sample-data) directly, rather than using the (provided) pre-processed version of this data. This adds extra dependencies:
 
 ```bash
 $ conda activate cchd
-$ conda install -c conda-forge iris-sample-data
+$ conda install -c conda-forge distributed iris-sample-data
 ```

--- a/cchd/climate_change_risk_dashboard_realtime.ipynb
+++ b/cchd/climate_change_risk_dashboard_realtime.ipynb
@@ -2,32 +2,27 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "underlying-powder",
+   "id": "average-firmware",
    "metadata": {},
    "source": [
-    "# Climate Change Risk Dashboard (Realtime)\n",
+    "# Climate Change Risk Dashboard \n",
+    "#### Realtime, processing in external module\n",
     "\n",
     "This dashboard is an example of highlighting risks due to climate change. In this case we study the mainland US and explore risk as a function of global heating, over the period of 1860 - 2100, and comparing the climatic future scenarios A1B and E1.\n",
     "\n",
-    "A measure of human vulnerability and risk is also synthesized and shown as points over the centres of each state. Vulnerability to the hazard (global heating) is shown by the brightness of the point, and the risk the hazard poses is shown by the size of the point.\n",
-    "\n",
-    "This version of the dashboard calculates statistics (in-state average temperature and risk metric; anomaly period means _are_ pre-calculated due to their constant nature) in realtime, rather than being fully reliant on pre-computed data to populate the dashboard."
+    "This version of the dashboard calculates statistics (specifically in-state average temperature) in realtime, rather than being fully reliant on pre-computed data to populate the dashboard."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "catholic-proportion",
+   "id": "southern-motel",
    "metadata": {},
    "outputs": [],
    "source": [
-    "import os\n",
-    "import warnings\n",
-    "\n",
-    "from bokeh.models import ColumnDataSource\n",
-    "\n",
     "import cartopy.crs as ccrs\n",
-    "import cartopy.io.shapereader as shpreader\n",
+    "\n",
+    "from distributed import Client, LocalCluster\n",
     "\n",
     "import colorcet as cc\n",
     "import geoviews.feature as gf\n",
@@ -35,20 +30,13 @@
     "import panel as pn\n",
     "import param\n",
     "\n",
-    "import iris\n",
-    "\n",
-    "import numpy as np\n",
-    "\n",
-    "import geopandas as gpd\n",
-    "import pandas as pd\n",
-    "\n",
-    "import shapecutter"
+    "from processing import DataHolder"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "heavy-signal",
+   "id": "specialized-setup",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -57,158 +45,39 @@
   },
   {
    "cell_type": "markdown",
-   "id": "continuous-alexander",
+   "id": "engaged-reconstruction",
    "metadata": {},
    "source": [
-    "## Load and pre-process shapefile data"
+    "## Load all data"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "incorrect-password",
-   "metadata": {
-    "tags": []
-   },
-   "outputs": [],
-   "source": [
-    "# Load US states shapefile data.\n",
-    "us_states_name = shpreader.natural_earth(\n",
-    "    category=\"cultural\",\n",
-    "    name=\"admin_1_states_provinces\")\n",
-    "\n",
-    "us_states = gpd.read_file(us_states_name)\n",
-    "\n",
-    "# We only need to keep a few columns of data from the US states geodataframe (gdf).\n",
-    "gdf_drop_cols = list(set(us_states.columns) - set([\"name\", 'gn_a1_code', \"geometry\"]))\n",
-    "\n",
-    "us_states = us_states.drop(columns=gdf_drop_cols)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "agreed-nepal",
+   "id": "heard-denial",
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Add columns for the area and the centre of the geometry.\n",
-    "us_states[\"area\"] = us_states.apply(lambda r: r[\"geometry\"].area, axis=1)\n",
-    "# We do these two separately for the sake of simplicity.\n",
-    "us_states[\"latitude\"] = us_states.apply(lambda r: r[\"geometry\"].centroid.y, axis=1, result_type=\"expand\")\n",
-    "us_states[\"longitude\"] = us_states.apply(lambda r: r[\"geometry\"].centroid.x, axis=1, result_type=\"expand\")"
+    "processor = DataHolder()\n",
+    "state_codes = processor.state_codes"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "accepted-flavor",
-   "metadata": {},
-   "source": [
-    "## Climate data\n",
-    "\n",
-    "Load the climate data as Iris cubes and provide processing functions for this data."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "smaller-twist",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "a1b_cube = iris.load_cube(iris.sample_data_path(\"a1b_north_america.nc\"))\n",
-    "e1_cube = iris.load_cube(iris.sample_data_path(\"e1_north_america.nc\"))"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "bridal-bullet",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "def calculate_one_mean(state_code, rcp, year):\n",
-    "    \"\"\"\n",
-    "    Calculate one mean value, for a specific combination of US state (defined by its state code),\n",
-    "    RCP scenario and year.\n",
-    "    \n",
-    "    \"\"\"\n",
-    "    cube = a1b_cube if rcp.lower() == \"a1b\" else e1_cube\n",
-    "    cstr = iris.Constraint(time=lambda cell: cell.point.year == int(year))\n",
-    "    year_cube = cube.extract(cstr)\n",
-    "    geometry = us_states[us_states[\"gn_a1_code\"] == state_code][\"geometry\"]\n",
-    "    state_year_cube = shapecutter.cut_cube_to_shape(year_cube, geometry)\n",
-    "    if state_year_cube is not None:\n",
-    "        collapsed_cube = state_year_cube.collapsed([\"latitude\", \"longitude\"], iris.analysis.MEAN)\n",
-    "        result = float(collapsed_cube.data)\n",
-    "    else:\n",
-    "        result = None\n",
-    "    return result"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "varied-chapter",
+   "id": "velvet-passing",
    "metadata": {},
    "source": [
     "## Interactive and Realtime Plot\n",
     "\n",
-    "Produce an interactive plot that calculates mean temperatures within states for a selected year and RCP scenario in an on-demand fashion.\n",
-    "\n",
-    "### Basic Interface\n",
-    "\n",
-    "This interface works (🎉) but it's a bit clunky - notably casting the polygons into a holoviews Pane loses the extent that's otherwise set tight to the limits of the polygons being plotted. Also we are not able to show coastlines on this interface, due to type inconsistencies between the coastlines feature and the holoviews Pane, again.\n",
-    "\n",
-    "**Note:** commented out so that running the notebook as a Panel app isn't slowed down by this cell executing before the servable app below gets executed."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "present-potential",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# rcp = pn.widgets.Select(value=\"a1b\", options=[\"a1b\", \"e1\"], name=\"RCP\")\n",
-    "# year = pn.widgets.IntSlider(value=2021, start=1860, end=2099, step=1, name=\"Year\")\n",
-    "# button = pn.widgets.Button(name=\"Update\", button_type=\"primary\")\n",
-    "\n",
-    "# def plot(cdim=\"none\"):\n",
-    "#     return us_states.hvplot.polygons(geo=True,\n",
-    "#                                      c=cdim).opts(\n",
-    "#             toolbar=\"above\", clim=(255, 310),\n",
-    "#             projection=ccrs.LambertConformal(),\n",
-    "#             cmap=cc.cm.CET_L4, colorbar=True)\n",
-    "\n",
-    "# def _update(new_ind, rcp, year):\n",
-    "#     if new_ind not in us_states.columns:\n",
-    "#         with warnings.catch_warnings():\n",
-    "#             warnings.simplefilter(\"ignore\")\n",
-    "#             us_states[new_ind] = us_states.apply(\n",
-    "#                 lambda r: calculate_one_mean(r[\"gn_a1_code\"], rcp, year),\n",
-    "#                 axis=1)\n",
-    "\n",
-    "# default = f\"({rcp.value},{year.value})\"\n",
-    "# _update(default, rcp.value, year.value)\n",
-    "# gv_pane = pn.pane.HoloViews(plot(default))\n",
-    "\n",
-    "# def update(event):\n",
-    "#     new_ind = f\"({rcp.value},{year.value})\"\n",
-    "#     with pn.param.set_values(gv_pane, loading=True):\n",
-    "#         _update(new_ind, rcp.value, year.value)\n",
-    "#         gv_pane.object = plot(cdim=new_ind)\n",
-    "\n",
-    "# button.on_click(update)\n",
-    "\n",
-    "# pn.Row(pn.Column(rcp, year, button), gv_pane)"
+    "Produce an interactive plot that calculates mean temperatures within states for a selected year and RCP scenario in an on-demand fashion."
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "driven-disclaimer",
+   "id": "banned-jefferson",
    "metadata": {},
    "source": [
-    "## Full interface\n",
+    "### Full interface\n",
     "\n",
     "This takes the `ClimateRiskInterface` from the non-realtime dashboard, strips out extra calculations such as risk calculation, and adds a simple method that calculates mean temperature within a state for a given year and RCP in realtime. We wrap the plot in a `pn.panel` call so that we can put a spinning-wheel loading indicator over the plot while the calculations run in realtime, and so that the interface does not lock up while the calculations execute.\n",
     "\n",
@@ -218,7 +87,22 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "molecular-detective",
+   "id": "attempted-width",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Create a local dask distributed cluster for processing statistics in realtime.\n",
+    "\n",
+    "# Important: multiple threads cause distributed processing to lock up.\n",
+    "lc = LocalCluster(n_workers=8, threads_per_worker=1)\n",
+    "c = Client(lc)\n",
+    "c"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "creative-tokyo",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -228,28 +112,19 @@
     "    year = param.Integer(default=2021, bounds=(1860, 2099))\n",
     "    \n",
     "    # Set some defaults.\n",
-    "    tmin, tmax = 255, 310\n",
-    "    \n",
-    "    def _update(self, new_ind):\n",
-    "        if new_ind not in us_states.columns:\n",
-    "            with warnings.catch_warnings():  # Explicitly silence Iris collapse warnings.\n",
-    "                warnings.simplefilter(\"ignore\")\n",
-    "                us_states[new_ind] = us_states.apply(\n",
-    "                    lambda r: calculate_one_mean(r[\"gn_a1_code\"], self.rcp, self.year),\n",
-    "                    axis=1)\n",
-    "    \n",
+    "    tmin, tmax = 255, 308\n",
+    "\n",
     "    def prepare_data(self, col_ref):\n",
-    "        \"\"\"Set up the data to show in the filled polygons.\"\"\"\n",
-    "        self._update(col_ref)\n",
-    "        return us_states[col_ref]\n",
+    "        processor.calculate_one_column(col_ref)\n",
+    "        return processor.us_states[col_ref]\n",
     "    \n",
     "    @param.depends(\"rcp\", \"year\")\n",
     "    def plot(self):\n",
     "        \"\"\"Plot all the elements of the map.\"\"\"\n",
-    "        col_ref = f\"({self.rcp},{self.year})\"\n",
-    "        polyplot = us_states.hvplot.polygons(geo=True,\n",
-    "                                        c=self.prepare_data(col_ref),\n",
-    "                                        hover_cols=[\"name\", col_ref]).opts(\n",
+    "        col_ref = f\"{self.rcp},{self.year}\"\n",
+    "        polyplot = processor.us_states.hvplot.polygons(geo=True,\n",
+    "                                                       c=self.prepare_data(col_ref),\n",
+    "                                                       hover_cols=[\"name\"]).opts(\n",
     "            toolbar=\"above\", clim=(self.tmin, self.tmax),\n",
     "            projection=ccrs.LambertConformal(),\n",
     "            cmap=cc.cm.CET_L4, colorbar=True)\n",
@@ -261,17 +136,21 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "medium-separation",
+   "id": "official-toddler",
    "metadata": {},
    "outputs": [],
    "source": [
     "interface = ClimateRiskInterfaceRT()\n",
-    "\n",
-    "# button = pn.widgets.Button(name=\"Update\", button_type=\"primary\")\n",
-    "# button.on_click(interface.update)\n",
-    "\n",
     "pn.Row(interface.param, pn.panel(interface.plot, loading_indicator=True)).servable()"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "super-character",
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {

--- a/cchd/processing.py
+++ b/cchd/processing.py
@@ -1,0 +1,140 @@
+"""
+Separate out the processing functions for the realtime & parallel dashboard
+into a separate module.
+
+For more information, see:
+  1. https://discourse.holoviz.org/t/can-i-load-data-asynchronously-in-panel/452/11
+     (particularly "update 2" in that post), and
+  2. https://discourse.bokeh.org/t/pickling-problem-bokeh-server/3394
+     (linked in 1.)
+
+"""
+
+import warnings
+
+import cartopy.io.shapereader as shpreader
+import dask.bag as db
+import geopandas as gpd
+import iris
+import pandas as pd
+
+import shapecutter
+
+
+class DataHolder(object):
+    """A container for app-specific data and analysis methods."""
+    def __init__(self):
+        self._state_code_name = 'gn_a1_code'
+        
+        self._a1b_cube = None
+        self._e1_cube = None
+        self._us_states = None
+        self._state_codes = None
+        
+    @property
+    def a1b_cube(self):
+        ref = "a1b"
+        if self._a1b_cube is None:
+            self.a1b_cube = self.prepare_cube(ref)
+        return self._a1b_cube
+    
+    @a1b_cube.setter
+    def a1b_cube(self, value):
+        self._a1b_cube = value
+        
+    @property
+    def e1_cube(self):
+        ref = "e1"
+        if self._e1_cube is None:
+            self.e1_cube = self.prepare_cube(ref)
+        return self._e1_cube
+    
+    @e1_cube.setter
+    def e1_cube(self, value):
+        self._e1_cube = value
+        
+    @property
+    def us_states(self):
+        if self._us_states is None:
+            self.us_states = self.prepare_df()
+        return self._us_states
+    
+    @us_states.setter
+    def us_states(self, value):
+        self._us_states = value
+        
+    @property
+    def state_codes(self):
+        if self._state_codes is None:
+            self.state_codes = self.us_states['gn_a1_code']
+        return self._state_codes
+    
+    @state_codes.setter
+    def state_codes(self, value):
+        self._state_codes = value
+
+    def prepare_cube(self, ref):
+        """Load a specific dataset from the Iris sample data as an Iris cube."""
+        return iris.load_cube(iris.sample_data_path(f"{ref}_north_america.nc"))
+
+    def prepare_df(self):
+        """Load US states shapefile data."""
+        us_states_name = shpreader.natural_earth(
+            category="cultural",
+            name="admin_1_states_provinces")
+        us_states = gpd.read_file(us_states_name)
+
+        # We only need to keep a few columns of data from the US states geodataframe (gdf).
+        gdf_drop_cols = list(set(us_states.columns) - set(["name", self._state_code_name, "geometry"]))
+        us_states = us_states.drop(columns=gdf_drop_cols)
+        
+        # Add columns for the area and the centre of the geometry.
+        us_states["area"] = us_states.apply(lambda r: r["geometry"].area, axis=1)
+        # We do these two separately for the sake of simplicity.
+        us_states["latitude"] = us_states.apply(lambda r: r["geometry"].centroid.y, axis=1)
+        us_states["longitude"] = us_states.apply(lambda r: r["geometry"].centroid.x, axis=1)
+        
+        return us_states
+
+    def calculate_one_mean(self, state_code, rcp, year):
+        """_
+        Calculate one mean value, for a specific combination of US state (defined by its state code),
+        RCP scenario and year.
+
+        """
+        cube = self.a1b_cube if rcp.lower() == "a1b" else self.e1_cube
+        cstr = iris.Constraint(time=lambda cell: cell.point.year == int(year))
+        year_cube = cube.extract(cstr)
+        geometry = self.us_states[self.us_states[self._state_code_name] == state_code]["geometry"]
+        state_year_cube = shapecutter.cut_cube_to_shape(year_cube, geometry)
+        if state_year_cube is not None:
+            collapsed_cube = state_year_cube.collapsed(["latitude", "longitude"], iris.analysis.MEAN)
+            result = float(collapsed_cube.data)
+        else:
+            result = None
+        return result
+    
+    def _update(self, state_code, year, rcp):
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            result = self.calculate_one_mean(state_code, rcp, year)
+        return (state_code, result)
+
+    def _update_handler(self, args):
+        return self._update(*args)
+    
+    def calculate_one_column(self, col_ref):
+        """
+        Calculate one column of results for the dataframe. This will contain the results
+        for one specific combination of rcp and year, which is encoded in the column ref
+        `col_ref`.
+        
+        """
+        rcp, year = col_ref.split(",")
+        if col_ref not in self.us_states.columns:
+            seq = zip(self.state_codes, [year]*len(self.state_codes), [rcp]*len(self.state_codes))
+            state_codes_bag = db.from_sequence(seq)
+            results = state_codes_bag.map(self._update_handler).compute()
+            states, temps = list(zip(*results))
+            result_df = pd.DataFrame({self._state_code_name: states, col_ref: temps})
+            self.us_states = pd.merge(self.us_states, result_df, on=self._state_code_name)


### PR DESCRIPTION
Use dask distributed to parallelise processing of mean in-state values for a specific combination of input parameters. This speeds up the processing of each combination so that the dashboard appears more responsive.

Dask cannot be used directly with served panel/bokeh applications due to a serialization issue. More details on this can be found at https://discourse.holoviz.org/t/can-i-load-data-asynchronously-in-panel/452/11 and https://discourse.bokeh.org/t/pickling-problem-bokeh-server/3394 (also linked from the first item). This means a new Python module; `processing.py`, has been introduced, which encapsulates all the parallelised processing separately to the served application.

Calculated results from each combination continue to be written to the in-memory geopandas dataframe that underpins the dashboard. As well as simplifying the dashboard it means the geodataframe can be used as a simple cache to avoid recalculating values for combinations that have already been selected. The cache lasts for the length of the session.

